### PR TITLE
CD-8187 node version upgrade from 10 to 22

### DIFF
--- a/common/ts/package-lock.json
+++ b/common/ts/package-lock.json
@@ -10,11 +10,11 @@
       "license": "LGPL-3.0",
       "dependencies": {
         "azure-devops-node-api": "^12.1.0",
-        "azure-pipelines-task-lib": "4.7.0",
+        "azure-pipelines-task-lib": "4.13.0",
         "fs-extra": "5.0.0",
         "guid-typescript": "1.0.9",
         "node-fetch": "2.7.0",
-        "semver": "5.7.1"
+        "semver": "5.7.2"
       },
       "engines": {
         "node": ">=6"
@@ -49,12 +49,12 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.7.0.tgz",
-      "integrity": "sha512-5MctDC1Bt7eFi9tQTXlikuWRDc2MenCNruMsEwcKuXqBj1ZY+fA/D+E1DbE0Qi2u8kl1p6szT0we8k6RHSOe/w==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.13.0.tgz",
+      "integrity": "sha512-KVguui31If98vgokNepHUxE3/D8UFB4FHV1U6XxjGOkgxxwKxbupC3knVnEiZA/hNl7X+vmj9KrYOx79iwmezQ==",
+      "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
-        "deasync": "^0.1.28",
         "minimatch": "3.0.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
@@ -67,14 +67,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -107,19 +99,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
-    "node_modules/deasync": {
-      "version": "0.1.29",
-      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.29.tgz",
-      "integrity": "sha512-EBtfUhVX23CE9GR6m+F8WPeImEE4hR/FW9RkK0PMl9V1t283s0elqsTD8EZjaKX28SY1BW2rYfCgNsAYdpamUw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^1.7.1"
-      },
-      "engines": {
-        "node": ">=0.11.0"
-      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -171,11 +150,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/follow-redirects": {
       "version": "1.15.6",
@@ -420,11 +394,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/node-addon-api": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -543,9 +512,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }

--- a/commonv5/ts/package-lock.json
+++ b/commonv5/ts/package-lock.json
@@ -15,7 +15,7 @@
         "guid-typescript": "1.0.9",
         "hpagent": "1.2.0",
         "node-fetch": "2.7.0",
-        "semver": "5.7.1"
+        "semver": "5.7.2"
       },
       "engines": {
         "node": ">=6"
@@ -558,9 +558,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }

--- a/config/utils.js
+++ b/config/utils.js
@@ -274,7 +274,7 @@ function copyIconsTask(icon = 'task_icon.png') {
     mergeStream(
       globby.sync(path.join(paths.extensions.root, '*'), { nodir: false }).map(extension => {
         let iconPipe = gulp
-          .src(path.join(extension, 'tasks_icons', icon))
+          .src(path.join(extension, 'tasks_icons', icon), { allowEmpty: true })
           .pipe(gulpRename('icon.png'));
         globby.sync(path.join(extension, 'tasks', '*', '*'), { nodir: false }).forEach(dir => {
           iconPipe = iconPipe.pipe(

--- a/extensions/codescancloud/tasks/analyze/v1/task.json
+++ b/extensions/codescancloud/tasks/analyze/v1/task.json
@@ -12,7 +12,7 @@
     "Minor": 46,
     "Patch": 0
   },
-  "minimumAgentVersion": "3.244.1",
+  "minimumAgentVersion": "3.248.0",
   "demands": ["java"],
   "inputs": [
     {
@@ -31,7 +31,10 @@
     }
   ],
   "execution": {
-    "Node22_1": {
+    "Node24": {
+      "target": "analyze.js"
+    },
+    "Node20_1": {
       "target": "analyze.js"
     }
   }

--- a/extensions/codescancloud/tasks/analyze/v1/task.json
+++ b/extensions/codescancloud/tasks/analyze/v1/task.json
@@ -9,10 +9,10 @@
   "author": "codescansf",
   "version": {
     "Major": 1,
-    "Minor": 45,
+    "Minor": 46,
     "Patch": 0
   },
-  "minimumAgentVersion": "2.144.0",
+  "minimumAgentVersion": "3.244.1",
   "demands": ["java"],
   "inputs": [
     {
@@ -31,7 +31,7 @@
     }
   ],
   "execution": {
-    "Node10": {
+    "Node22_1": {
       "target": "analyze.js"
     }
   }

--- a/extensions/codescancloud/tasks/prepare/v1/task.json
+++ b/extensions/codescancloud/tasks/prepare/v1/task.json
@@ -11,10 +11,10 @@
   "author": "codescansf",
   "version": {
     "Major": 1,
-    "Minor": 41,
+    "Minor": 42,
     "Patch": 0
   },
-  "minimumAgentVersion": "2.144.0",
+  "minimumAgentVersion": "3.244.1",
   "instanceNameFormat": "Prepare analysis on CodeScan Cloud",
   "groups": [
     {
@@ -159,7 +159,7 @@
     }
   ],
   "execution": {
-    "Node10": {
+    "Node22_1": {
       "target": "prepare.js"
     }
   }

--- a/extensions/codescancloud/tasks/prepare/v1/task.json
+++ b/extensions/codescancloud/tasks/prepare/v1/task.json
@@ -14,7 +14,7 @@
     "Minor": 42,
     "Patch": 0
   },
-  "minimumAgentVersion": "3.244.1",
+  "minimumAgentVersion": "3.248.0",
   "instanceNameFormat": "Prepare analysis on CodeScan Cloud",
   "groups": [
     {
@@ -159,7 +159,10 @@
     }
   ],
   "execution": {
-    "Node22_1": {
+    "Node24": {
+      "target": "prepare.js"
+    },
+    "Node20_1": {
       "target": "prepare.js"
     }
   }

--- a/extensions/codescancloud/tasks/publish/v1/task.json
+++ b/extensions/codescancloud/tasks/publish/v1/task.json
@@ -11,10 +11,10 @@
   "author": "codescansf",
   "version": {
     "Major": 1,
-    "Minor": 16,
+    "Minor": 17,
     "Patch": 0
   },
-  "minimumAgentVersion": "2.144.0",
+  "minimumAgentVersion": "3.244.1",
   "inputs": [
     {
       "name": "pollingTimeoutSec",
@@ -28,7 +28,7 @@
   ],
   "dataSourceBindings": [],
   "execution": {
-    "Node10": {
+    "Node22_1": {
       "target": "publish.js"
     }
   }

--- a/extensions/codescancloud/tasks/publish/v1/task.json
+++ b/extensions/codescancloud/tasks/publish/v1/task.json
@@ -14,7 +14,7 @@
     "Minor": 17,
     "Patch": 0
   },
-  "minimumAgentVersion": "3.244.1",
+  "minimumAgentVersion": "3.248.0",
   "inputs": [
     {
       "name": "pollingTimeoutSec",
@@ -28,7 +28,10 @@
   ],
   "dataSourceBindings": [],
   "execution": {
-    "Node22_1": {
+    "Node24": {
+      "target": "publish.js"
+    },
+    "Node20_1": {
       "target": "publish.js"
     }
   }

--- a/extensions/codescancloud/vss-extension.json
+++ b/extensions/codescancloud/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "codescan",
   "name": "CodeScan Cloud",
-  "version": "2.1.3",
+  "version": "3.0.0",
   "branding": {
     "color": "rgb(243, 243, 243)",
     "theme": "light"

--- a/extensions/codescancloud/vss-extension.json
+++ b/extensions/codescancloud/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "codescan",
   "name": "CodeScan Cloud",
-  "version": "2.0.1",
+  "version": "2.1.3",
   "branding": {
     "color": "rgb(243, 243, 243)",
     "theme": "light"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.2-SNAPSHOT",
       "license": "LGPL-3.0",
       "dependencies": {
-        "azure-pipelines-task-lib": "4.7.0"
+        "azure-pipelines-task-lib": "4.13.0"
       },
       "devDependencies": {
         "@cyclonedx/bom": "^3.8.0",
@@ -18,7 +18,7 @@
         "@types/jest-when": "2.7.3",
         "@types/node": "14.14.31",
         "@types/node-fetch": "^2.6.9",
-        "@types/semver": "5.5.0",
+        "@types/semver": "7.5.8",
         "@types/tmp": "0.2.1",
         "@types/yargs": "13.0.2",
         "@typescript-eslint/parser": "5.59.11",
@@ -50,7 +50,7 @@
         "node-fetch": "^2.7.0",
         "openpgp": "5.10.1",
         "prettier": "3.0.3",
-        "semver": "5.5.0",
+        "semver": "5.7.2",
         "sonarqube-scanner": "3.3.0",
         "stream": "^0.0.2",
         "tfx-cli": "0.16.0",
@@ -1693,10 +1693,11 @@
       }
     },
     "node_modules/@types/semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
-      "dev": true
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -2670,12 +2671,12 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.7.0.tgz",
-      "integrity": "sha512-5MctDC1Bt7eFi9tQTXlikuWRDc2MenCNruMsEwcKuXqBj1ZY+fA/D+E1DbE0Qi2u8kl1p6szT0we8k6RHSOe/w==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.13.0.tgz",
+      "integrity": "sha512-KVguui31If98vgokNepHUxE3/D8UFB4FHV1U6XxjGOkgxxwKxbupC3knVnEiZA/hNl7X+vmj9KrYOx79iwmezQ==",
+      "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
-        "deasync": "^0.1.28",
         "minimatch": "3.0.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
@@ -3021,6 +3022,8 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -3936,19 +3939,6 @@
       "dev": true,
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/deasync": {
-      "version": "0.1.29",
-      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.29.tgz",
-      "integrity": "sha512-EBtfUhVX23CE9GR6m+F8WPeImEE4hR/FW9RkK0PMl9V1t283s0elqsTD8EZjaKX28SY1BW2rYfCgNsAYdpamUw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^1.7.1"
-      },
-      "engines": {
-        "node": ">=0.11.0"
       }
     },
     "node_modules/debug": {
@@ -5500,7 +5490,9 @@
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/fill-range": {
       "version": "4.0.0",
@@ -9720,11 +9712,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
-    "node_modules/node-addon-api": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
-    },
     "node_modules/node-downloader-helper": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/node-downloader-helper/-/node-downloader-helper-2.1.9.tgz",
@@ -11553,9 +11540,10 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }


### PR DESCRIPTION
This ticket is to upgrade the node version in our Azure DevOps Tasks.  

The current version is 10.

for compatible minimumAgentVersion :

 for node 22 :  "minimumAgentVersion": "3.244.1"
 refer : https://github.com/microsoft/azure-pipelines-task-lib/blob/master/node/docs/minagent.md
